### PR TITLE
Use in-toto v0.1.1 for demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ our software package `demo-project.tar.gz` and the related metadata files `root.
 `clone.[Bob's keyid].link`, `update-version.[Bob's keyid].link` and `package.[Carl's keyid].link`:
 ```shell
 cd ..
-cp owner_alice/root.layout functionary_bob/clone.0c6c50a1.link functionary_bob/update-version.0c6c50a1.link functionary_carl/package.c1ae1e51.link functionary_carl/demo-project.tar.gz final_product/
+cp owner_alice/root.layout functionary_bob/clone.776a00e2.link functionary_bob/update-version.776a00e2.link functionary_carl/package.2f89b927.link functionary_carl/demo-project.tar.gz final_product/
 ```
 And now run verification on behalf of the client:
 ```shell
@@ -209,7 +209,7 @@ in-toto-run --step-name package --materials demo-project/foo.py --products demo-
 and ships everything out as final product to the client:
 ```shell
 cd ..
-cp owner_alice/root.layout functionary_bob/clone.0c6c50a1.link functionary_bob/update-version.0c6c50a1.link functionary_carl/package.c1ae1e51.link functionary_carl/demo-project.tar.gz final_product/
+cp owner_alice/root.layout functionary_bob/clone.776a00e2.link functionary_bob/update-version.776a00e2.link functionary_carl/package.2f89b927.link functionary_carl/demo-project.tar.gz final_product/
 ```
 
 ### Verifying the malicious product

--- a/owner_alice/create_layout.py
+++ b/owner_alice/create_layout.py
@@ -1,5 +1,6 @@
 from in_toto.util import import_rsa_key_from_file
 from in_toto.models.layout import Layout
+from in_toto.models.metadata import Metablock
 
 def main():
   # Load Alice's private key to later sign the layout
@@ -10,7 +11,6 @@ def main():
   key_carl = import_rsa_key_from_file("../functionary_carl/carl.pub")
 
   layout = Layout.read({
-    "signed": {
       "_type": "layout",
       "keys": {
           key_bob["keyid"]: key_bob,
@@ -68,13 +68,13 @@ def main():
           ],
           "run": "tar xzf demo-project.tar.gz",
         }],
-    },
-    "signatures": []
   })
 
-  # Sign and dump layout to "layout.root"
-  layout.sign(key_alice)
-  layout.dump()
+  metadata = Metablock(signed=layout)
+
+  # Sign and dump layout to "root.layout"
+  metadata.sign(key_alice)
+  metadata.dump("root.layout")
 
 if __name__ == '__main__':
   main()

--- a/owner_alice/create_layout.py
+++ b/owner_alice/create_layout.py
@@ -19,15 +19,15 @@ def main():
       "steps": [{
           "name": "clone",
           "expected_materials": [],
-          "expected_products": [["CREATE", "demo-project/foo.py"]],
+          "expected_products": [["CREATE", "demo-project/foo.py"], ["DISALLOW", "*"]],
           "pubkeys": [key_bob["keyid"]],
           "expected_command": "git clone https://github.com/in-toto/demo-project.git",
           "threshold": 1,
         },{
           "name": "update-version",
           "expected_materials": [["MATCH", "demo-project/*", "WITH", "PRODUCTS",
-                                "FROM", "clone"]],
-          "expected_products": [["ALLOW", "demo-project/foo.py"]],
+                                "FROM", "clone"], ["DISALLOW", "*"]],
+          "expected_products": [["ALLOW", "demo-project/foo.py"], ["DISALLOW", "*"]],
           "pubkeys": [key_bob["keyid"]],
           "expected_command": "",
           "threshold": 1,
@@ -35,10 +35,10 @@ def main():
           "name": "package",
           "expected_materials": [
             ["MATCH", "demo-project/*", "WITH", "PRODUCTS", "FROM",
-             "update-version"],
+             "update-version"], ["DISALLOW", "*"],
           ],
           "expected_products": [
-              ["CREATE", "demo-project.tar.gz"],
+              ["CREATE", "demo-project.tar.gz"], ["DISALLOW", "*"],
           ],
           "pubkeys": [key_carl["keyid"]],
           "expected_command": "tar --exclude '.git' -zcvf demo-project.tar.gz demo-project",
@@ -54,6 +54,7 @@ def main():
               ["ALLOW", ".keep"],
               ["ALLOW", "alice.pub"],
               ["ALLOW", "root.layout"],
+              ["DISALLOW", "*"]
           ],
           "expected_products": [
               ["MATCH", "demo-project/foo.py", "WITH", "PRODUCTS", "FROM", "update-version"],
@@ -63,6 +64,7 @@ def main():
               ["ALLOW", ".keep"],
               ["ALLOW", "alice.pub"],
               ["ALLOW", "root.layout"],
+              ["DISALLOW", "*"]
           ],
           "run": "tar xzf demo-project.tar.gz",
         }],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git://github.com/in-toto/in-toto.git@d91c5661313d38bee9a283e65508937bf0f20fa8#egg=in-toto
+in-toto==0.1.1

--- a/run_demo.py
+++ b/run_demo.py
@@ -74,9 +74,9 @@ def supply_chain():
   prompt_key("Create final product")
   os.chdir("..")
   copyfile("owner_alice/root.layout", "final_product/root.layout")
-  copyfile("functionary_bob/clone.0c6c50a1.link", "final_product/clone.0c6c50a1.link")
-  copyfile("functionary_bob/update-version.0c6c50a1.link", "final_product/update-version.0c6c50a1.link")
-  copyfile("functionary_carl/package.c1ae1e51.link", "final_product/package.c1ae1e51.link")
+  copyfile("functionary_bob/clone.776a00e2.link", "final_product/clone.776a00e2.link")
+  copyfile("functionary_bob/update-version.776a00e2.link", "final_product/update-version.776a00e2.link")
+  copyfile("functionary_carl/package.2f89b927.link", "final_product/package.2f89b927.link")
   copyfile("functionary_carl/demo-project.tar.gz", "final_product/demo-project.tar.gz")
 
 
@@ -114,9 +114,9 @@ def supply_chain():
   prompt_key("Create final product")
   os.chdir("..")
   copyfile("owner_alice/root.layout", "final_product/root.layout")
-  copyfile("functionary_bob/clone.0c6c50a1.link", "final_product/clone.0c6c50a1.link")
-  copyfile("functionary_bob/update-version.0c6c50a1.link", "final_product/update-version.0c6c50a1.link")
-  copyfile("functionary_carl/package.c1ae1e51.link", "final_product/package.c1ae1e51.link")
+  copyfile("functionary_bob/clone.776a00e2.link", "final_product/clone.776a00e2.link")
+  copyfile("functionary_bob/update-version.776a00e2.link", "final_product/update-version.776a00e2.link")
+  copyfile("functionary_carl/package.2f89b927.link", "final_product/package.2f89b927.link")
   copyfile("functionary_carl/demo-project.tar.gz", "final_product/demo-project.tar.gz")
 
 
@@ -143,17 +143,17 @@ def main():
   if args.clean:
     files_to_delete = [
       "owner_alice/root.layout",
-      "functionary_bob/clone.0c6c50a1.link",
-      "functionary_bob/update-version.0c6c50a1.link",
+      "functionary_bob/clone.776a00e2.link",
+      "functionary_bob/update-version.776a00e2.link",
       "functionary_bob/demo-project",
-      "functionary_carl/package.c1ae1e51.link",
+      "functionary_carl/package.2f89b927.link",
       "functionary_carl/demo-project.tar.gz",
       "functionary_carl/demo-project",
       "final_product/alice.pub",
       "final_product/demo-project.tar.gz",
-      "final_product/package.c1ae1e51.link",
-      "final_product/clone.0c6c50a1.link",
-      "final_product/update-version.0c6c50a1.link",
+      "final_product/package.2f89b927.link",
+      "final_product/clone.776a00e2.link",
+      "final_product/update-version.776a00e2.link",
       "final_product/untar.link",
       "final_product/root.layout",
       "final_product/demo-project",

--- a/run_demo.py
+++ b/run_demo.py
@@ -65,7 +65,7 @@ def supply_chain():
   package_cmd = ("in-toto-run"
                  " --step-name package --materials demo-project/foo.py"
                  " --products demo-project.tar.gz"
-                 " --key carl --record-byproducts"
+                 " --key carl --record-streams"
                  " -- tar --exclude '.git' -zcvf demo-project.tar.gz demo-project")
   print package_cmd
   subprocess.call(shlex.split(package_cmd))
@@ -105,7 +105,7 @@ def supply_chain():
   package_cmd = ("in-toto-run"
                  " --step-name package --materials demo-project/foo.py"
                  " --products demo-project.tar.gz"
-                 " --key carl --record-byproducts"
+                 " --key carl --record-streams"
                  " -- tar --exclude '.git' -zcvf demo-project.tar.gz demo-project")
   print package_cmd
   subprocess.call(shlex.split(package_cmd))


### PR DESCRIPTION
Updating in-toto made the following changes to the demo scripts and docs necessary:

- update hardcoded keyids (required by new version of securesystemslib)
- refactor a command line flag to `in-toto-run`
- add explicit `DISALLOW *` (was implicit before)
- adopt new metadata object relations
- change version and location of in-toto requirement from GitHub/commit to (PyPi) name and version
