### PR TITLE
Use MODIFY rule for update-version step

### DIFF
--- a/owner_alice/create_layout.py
+++ b/owner_alice/create_layout.py
@@ -31,7 +31,7 @@ def main():
           "name": "update-version",
           "expected_materials": [["MATCH", "demo-project/*", "WITH", "PRODUCTS",
                                 "FROM", "clone"], ["DISALLOW", "*"]],
-          "expected_products": [["ALLOW", "demo-project/foo.py"], ["DISALLOW", "*"]],
+          "expected_products": [["MODIFY", "demo-project/foo.py"], ["DISALLOW", "*"]],
           "pubkeys": [key_bob["keyid"]],
           "expected_command": [],
           "threshold": 1,


### PR DESCRIPTION
cc @elfotografo007 We'd discussed this discrepancy some time ago. The MODIFY rule will inherently require the artifact to also be in the materials.