### PR TITLE
Add explicit allow rule for links in inspection

### DIFF
--- a/owner_alice/create_layout.py
+++ b/owner_alice/create_layout.py
@@ -67,6 +67,7 @@ def main():
               ["ALLOW", ".keep"],
               ["ALLOW", "alice.pub"],
               ["ALLOW", "root.layout"],
+              ["ALLOW", "*.link"],
               ["DISALLOW", "*"]
           ],
           "expected_products": [
@@ -77,6 +78,7 @@ def main():
               ["ALLOW", ".keep"],
               ["ALLOW", "alice.pub"],
               ["ALLOW", "root.layout"],
+              ["ALLOW", "*.link"],
               ["DISALLOW", "*"]
           ],
           "run": [


### PR DESCRIPTION
This isn't an issue when folks using the demo use in-toto-python but there have been a few instances now where users have tried the demo with in-toto-golang. As in-toto-golang does not have defaults for exclude patterns, the inspection fails. This PR adds a quick allow rule for the untar inspection.